### PR TITLE
Add flex-wrap class to dashboard filters row

### DIFF
--- a/frontend/src/metabase/dashboard/containers/Parameters.jsx
+++ b/frontend/src/metabase/dashboard/containers/Parameters.jsx
@@ -45,7 +45,7 @@ export default class Parameters extends Component {
             setParameterName, setParameterValue, setParameterDefaultValue, removeParameter
         } = this.props;
         return (
-            <div className="flex flex-row align-end">
+            <div className="flex flex-row align-end flex-wrap">
                 { parameters.map(parameter =>
                     <ParameterWidget
                         key={parameter.id}


### PR DESCRIPTION
Too many dashboard filters go off the screen, this allows to show them in multiple rows. https://github.com/metabase/metabase/issues/4328

![sshot-397](https://cloud.githubusercontent.com/assets/1549648/23561035/420c7824-0045-11e7-8708-b222a1ab9c4e.png)
